### PR TITLE
[round-1] 테스트 코드 제출 - 고동희

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,7 +11,9 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
 
     // querydsl
-    implementation("com.querydsl:querydsl-jpa::jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,0 +1,14 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.User;
+
+public record UserInfo(String userId, String gender, String birthDate, String email) {
+    public static UserInfo from(User user) {
+        return new UserInfo(
+                user.getUserId(),
+                user.getGender(),
+                user.getBirthDate(),
+                user.getEmail()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.user;
+package com.loopers.domain.point;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -9,7 +9,7 @@ public class Point {
 
     private final Long pointValue;
 
-    protected Point() {
+    public Point() {
         this.pointValue = 0L;
     }
 
@@ -18,9 +18,6 @@ public class Point {
         this.pointValue = pointValue;
     }
 
-    public Long getPointValue() {
-        return pointValue;
-    }
     public Point charge(Long amount) {
         validateChargeAmount(amount);
         return new Point(this.pointValue + amount);
@@ -29,6 +26,10 @@ public class Point {
     public Point use(Long amount) {
         validateUseAmount(amount);
         return new Point(this.pointValue - amount);
+    }
+
+    public Long getPointValue() {
+        return pointValue;
     }
 
     // =============================

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.user;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Point {
+
+    private Long amount;
+
+    protected Point() {
+        this.amount = 0L;
+    }
+
+    public Point(Long amount) {
+        this.amount = amount;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void add(Long points) {
+        this.amount += points;
+    }
+
+    public void deduct(Long points) throws IllegalAccessException {
+        if (this.amount < points) {
+            throw new IllegalAccessException("포인트가 부족합니다.");
+        }
+        this.amount -= points;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
@@ -45,13 +45,19 @@ public class Point {
     }
 
     private void validateChargeAmount(Long value) {
-        if (value == null || value <= 0) {
+        if (value == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "충전할 포인트 값이 null입니다.");
+        }
+        if (value <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "충전할 포인트는 0보다 커야 합니다.");
         }
     }
 
     private void validateUseAmount(Long value) {
-        if (value == null || value <= 0) {
+        if (value == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용할 포인트 값이 null입니다.");
+        }
+        if (value <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "사용할 포인트는 0보다 커야 합니다.");
         }
         if (this.pointValue < value) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.user;
 
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
@@ -20,6 +22,9 @@ public class Point {
     }
 
     public void add(Long points) {
+        if (points == null || points <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "충전 포인트는 0 이하의 정수가 될 수 없습니다.");
+        }
         this.amount += points;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
@@ -7,31 +7,55 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class Point {
 
-    private Long amount;
+    private final Long pointValue;
 
     protected Point() {
-        this.amount = 0L;
+        this.pointValue = 0L;
     }
 
-    public Point(Long amount) {
-        this.amount = amount;
+    public Point(Long pointValue) {
+        validateInitialValue(pointValue);
+        this.pointValue = pointValue;
     }
 
-    public Long getAmount() {
-        return amount;
+    public Long getPointValue() {
+        return pointValue;
+    }
+    public Point charge(Long amount) {
+        validateChargeAmount(amount);
+        return new Point(this.pointValue + amount);
     }
 
-    public void charge(Long points) {
-        if (points == null || points <= 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "충전 포인트는 0 이하의 정수가 될 수 없습니다.");
+    public Point use(Long amount) {
+        validateUseAmount(amount);
+        return new Point(this.pointValue - amount);
+    }
+
+    // =============================
+    // 🔒 Validation methods
+    // =============================
+
+    private void validateInitialValue(Long value) {
+        if (value == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트는 빈 값으로 생성될 수 없습니다.");
         }
-        this.amount += points;
+        if (value < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트는 음수로 생성될 수 없습니다.");
+        }
     }
 
-    public void use(Long points) throws IllegalAccessException {
-        if (this.amount < points) {
-            throw new IllegalAccessException("포인트가 부족합니다.");
+    private void validateChargeAmount(Long value) {
+        if (value == null || value <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "충전할 포인트는 0보다 커야 합니다.");
         }
-        this.amount -= points;
+    }
+
+    private void validateUseAmount(Long value) {
+        if (value == null || value <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용할 포인트는 0보다 커야 합니다.");
+        }
+        if (this.pointValue < value) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다.");
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Point.java
@@ -21,14 +21,14 @@ public class Point {
         return amount;
     }
 
-    public void add(Long points) {
+    public void charge(Long points) {
         if (points == null || points <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "충전 포인트는 0 이하의 정수가 될 수 없습니다.");
         }
         this.amount += points;
     }
 
-    public void deduct(Long points) throws IllegalAccessException {
+    public void use(Long points) throws IllegalAccessException {
         if (this.amount < points) {
             throw new IllegalAccessException("포인트가 부족합니다.");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,26 +1,41 @@
 package com.loopers.domain.user;
 
-import com.loopers.domain.example.BaseEntity;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "user")
+@Table(name = "member")
 public class User extends BaseEntity {
 
-    @Id
-    private String id;
+    @Column(name = "user_id", unique = true, nullable = false)
+    private String userId;
+    private String gender;
+    private String birthDate;
     private String email;
-    private String birthday;
 
     protected User() {}
 
-    public User(String id, String email, String birthday) {
-        this.id = id;
+    public User(String userId, String gender, String birthDate, String email) {
+        this.userId = userId;
+        this.gender = gender;
+        this.birthDate = birthDate;
         this.email = email;
-        this.birthday = birthday;
+    }
+
+    public String getUserId() { return userId; }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public String getBirthDate() {
+        return birthDate;
+    }
+
+    public String getEmail() {
+        return email;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -28,6 +28,7 @@ public class User extends BaseEntity {
         validateUserId(userId);
         validateEmail(email);
         validateBirthDate(birthDate);
+        validateGender(gender);
 
         this.userId = userId;
         this.gender = gender;
@@ -80,4 +81,15 @@ public class User extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식에 맞아야 합니다.");
         }
     }
+
+    private void validateGender(String gender) {
+        if (gender == null || gender.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 빈 값이 될 수 없습니다.");
+        }
+
+        if (!"F".equals(gender) && !"M".equals(gender)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 'F' 또는 'M'이어야 합니다.");
+        }
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -3,9 +3,7 @@ package com.loopers.domain.user;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -20,6 +18,9 @@ public class User extends BaseEntity {
     private String gender;
     private String birthDate;
     private String email;
+
+    @Embedded
+    private Point point = new Point();
 
     protected User() {}
 
@@ -42,13 +43,17 @@ public class User extends BaseEntity {
         return gender;
     }
 
-    public String getBirthDate() {
-        return birthDate;
-    }
+    public String getBirthDate() { return birthDate; }
 
     public String getEmail() {
         return email;
     }
+
+    public Long getPoint() { return point.getAmount(); }
+
+    public void addPoint(Long points) { this.point.add(points); }
+
+    public void deductPoint(Long points) throws IllegalAccessException { this.point.deduct(points); }
 
     private void validateUserId(String userId) {
         if (userId == null || userId.isBlank()) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,10 +1,15 @@
 package com.loopers.domain.user;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @Entity
 @Table(name = "member")
@@ -19,6 +24,11 @@ public class User extends BaseEntity {
     protected User() {}
 
     public User(String userId, String gender, String birthDate, String email) {
+
+        validateUserId(userId);
+        validateEmail(email);
+        validateBirthDate(birthDate);
+
         this.userId = userId;
         this.gender = gender;
         this.birthDate = birthDate;
@@ -37,5 +47,37 @@ public class User extends BaseEntity {
 
     public String getEmail() {
         return email;
+    }
+
+    private void validateUserId(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "ID는 빈 값이 될 수 없습니다.");
+        }
+
+        if (!userId.matches("^[a-zA-Z0-9]{1,10}$")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "ID는 영문 및 숫자 10자 이내여야 합니다.");
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 빈 값이 될 수 없습니다.");
+        }
+
+        if (!email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 xx@yy.zz 형식에 맞아야 합니다.");
+        }
+    }
+
+    private void validateBirthDate(String birthDate) {
+        if (birthDate == null || birthDate.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 빈 값이 될 수 없습니다.");
+        }
+
+        try {
+            LocalDate.parse(birthDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        } catch (DateTimeParseException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식에 맞아야 합니다.");
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -51,9 +51,9 @@ public class User extends BaseEntity {
 
     public Long getPoint() { return point.getAmount(); }
 
-    public void addPoint(Long points) { this.point.add(points); }
+    public void chargePoint(Long points) { this.point.charge(points); }
 
-    public void deductPoint(Long points) throws IllegalAccessException { this.point.deduct(points); }
+    public void usePoint(Long points) throws IllegalAccessException { this.point.use(points); }
 
     private void validateUserId(String userId) {
         if (userId == null || userId.isBlank()) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.example.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "user")
+public class User extends BaseEntity {
+
+    @Id
+    private String id;
+    private String email;
+    private String birthday;
+
+    protected User() {}
+
+    public User(String id, String email, String birthday) {
+        this.id = id;
+        this.email = email;
+        this.birthday = birthday;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -49,11 +49,15 @@ public class User extends BaseEntity {
         return email;
     }
 
-    public Long getPoint() { return point.getAmount(); }
+    public Long getPoint() { return point.getPointValue(); }
 
-    public void chargePoint(Long points) { this.point.charge(points); }
+    public void chargePoint(Long points) {
+        this.point = this.point.charge(points);
+    }
 
-    public void usePoint(Long points) throws IllegalAccessException { this.point.use(points); }
+    public void usePoint(Long points) throws IllegalAccessException {
+        this.point = this.point.use(points);
+    }
 
     private void validateUserId(String userId) {
         if (userId == null || userId.isBlank()) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.user;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.point.Point;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.user;
+
+public class UserCommand {
+
+    public record Create (String userId, String gender, String birthDate, String email) {
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserId.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserId.java
@@ -1,0 +1,38 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+public class UserId {
+    private final String value;
+
+    public UserId(String value) {
+        if (value == null || value.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 헤더가 누락되었습니다.");
+        }
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    // Optional: equals, hashCode, toString 오버라이딩 (도메인 테스트나 로그에 유리)
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserId)) return false;
+        UserId userId = (UserId) o;
+        return value.equals(userId.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserInfo.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.user;
 
 public record UserInfo(String userId, String gender, String birthDate, String email) {
+    // record로 객체 선언 시, get 메소드는 자동으로 생성됨
     public static UserInfo from(User user) {
         return new UserInfo(
                 user.getUserId(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserInfo.java
@@ -1,6 +1,4 @@
-package com.loopers.application.user;
-
-import com.loopers.domain.user.User;
+package com.loopers.domain.user;
 
 public record UserInfo(String userId, String gender, String birthDate, String email) {
     public static UserInfo from(User user) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.user;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    Optional<User> find(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -3,5 +3,7 @@ package com.loopers.domain.user;
 import java.util.Optional;
 
 public interface UserRepository {
-    Optional<User> find(Long id);
+    Optional<User> find(String userId);
+    User save(User user);
+    boolean existsByUserId(String userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -46,7 +46,7 @@ public class UserService {
                 .orElse(null);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Long chargePoints(String userId, Long amount) {
         return userRepository.find(userId)
                 .map(user -> {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.user;
 
-import com.loopers.application.user.UserInfo;
-import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -15,27 +13,29 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public User getUser(String userId) {
-        return userRepository.find(userId)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 회원을 찾을 수 없습니다."));
-    }
-
-    @Transactional(readOnly = true)
     public UserInfo getUserInfo(String userId) {
-        User user = getUser(userId);
+        User user = userRepository.find(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 회원을 찾을 수 없습니다."));
         return UserInfo.from(user);
     }
 
-    public User signUp(UserV1Dto.UserRequest request) {
-        if (userRepository.existsByUserId(request.userId())) {
+    @Transactional
+    public UserInfo signUp(UserCommand.Create command) {
+        if (userRepository.existsByUserId(command.userId())) {
             throw new CoreException(ErrorType.CONFLICT, "이미 가입된 ID 입니다.");
         }
+
+        if (command.gender() == null || command.gender().isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별이 없습니다.");
+        }
         User user = new User(
-                request.userId(),
-                request.gender(),
-                request.birthDate(),
-                request.email()
+                command.userId(),
+                command.gender(),
+                command.birthDate(),
+                command.email()
         );
-        return userRepository.save(user);
+
+        User saved = userRepository.save(user);
+        return UserInfo.from(saved);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
     public UserInfo getUserInfo(String userId) {
         return userRepository.find(userId)
                 .map(UserInfo::from)
-                .orElse(null);
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 ID의 회원이 없습니다."));
     }
 
     @Transactional

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -45,4 +45,14 @@ public class UserService {
                 .map(User::getPoint)
                 .orElse(null);
     }
+
+    @Transactional(readOnly = true)
+    public Long chargePoints(String userId, Long amount) {
+        return userRepository.find(userId)
+                .map(user -> {
+                    user.addPoint(amount);
+                    return user.getPoint();
+                })
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 ID의 회원이 없습니다."));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -38,4 +38,11 @@ public class UserService {
         User saved = userRepository.save(user);
         return UserInfo.from(saved);
     }
+
+    @Transactional(readOnly = true)
+    public Long getPoints(String userId) {
+        return userRepository.find(userId)
+                .map(User::getPoint)
+                .orElse(null);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -14,9 +14,9 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserInfo getUserInfo(String userId) {
-        User user = userRepository.find(userId)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 회원을 찾을 수 없습니다."));
-        return UserInfo.from(user);
+        return userRepository.find(userId)
+                .map(UserInfo::from)
+                .orElse(null);
     }
 
     @Transactional

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,41 @@
+package com.loopers.domain.user;
+
+import com.loopers.application.user.UserInfo;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User getUser(String userId) {
+        return userRepository.find(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 회원을 찾을 수 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public UserInfo getUserInfo(String userId) {
+        User user = getUser(userId);
+        return UserInfo.from(user);
+    }
+
+    public User signUp(UserV1Dto.UserRequest request) {
+        if (userRepository.existsByUserId(request.userId())) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 가입된 ID 입니다.");
+        }
+        User user = new User(
+                request.userId(),
+                request.gender(),
+                request.birthDate(),
+                request.email()
+        );
+        return userRepository.save(user);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -50,7 +50,7 @@ public class UserService {
     public Long chargePoints(String userId, Long amount) {
         return userRepository.find(userId)
                 .map(user -> {
-                    user.addPoint(amount);
+                    user.chargePoint(amount);
                     return user.getPoint();
                 })
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 ID의 회원이 없습니다."));

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -3,4 +3,10 @@ package com.loopers.infrastructure.user;
 import com.loopers.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserJpaRepository extends JpaRepository<User, Long> {}
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserId(String userId);
+
+    boolean existsByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> find(Long id) {
+        return userJpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -13,7 +13,17 @@ public class UserRepositoryImpl implements UserRepository {
     private final UserJpaRepository userJpaRepository;
 
     @Override
-    public Optional<User> find(Long id) {
-        return userJpaRepository.findById(id);
+    public Optional<User> find(String userId) {
+        return userJpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+
+    @Override
+    public boolean existsByUserId(String userId) {
+        return userJpaRepository.existsByUserId(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -3,8 +3,11 @@ package com.loopers.interfaces.api.point;
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Point V1 API", description = "포인트 관련 API 입니다.")
 public interface PointV1ApiSpec {
@@ -19,12 +22,13 @@ public interface PointV1ApiSpec {
         String userId
     );
 
-    /*@Operation(
-            summary = "회원 가입",
-            description = "회원 가입 정보를 입력하여 회원을 등록합니다."
+    @Operation(
+            summary = "포인트 충전",
+            description = "X-USER-ID 헤더와 충전할 포인트 값을 통해 포인트를 충전합니다."
     )
-    @PostMapping("/")
-    ApiResponse<UserV1Dto.UserResponse> signUp(
-            @RequestBody UserV1Dto.UserRequest userRequest
-    );*/
+    @PostMapping("/charge")
+    ApiResponse<Long> chargePoint(
+            @RequestHeader ("X-USER-ID") String userId,
+            @RequestBody PointV1Dto.PointChargeRequest request
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "Point V1 API", description = "포인트 관련 API 입니다.")
+public interface PointV1ApiSpec {
+
+    @Operation(
+        summary = "포인트 조회",
+        description = "X-USER-ID 헤더를 통해 포인트를 조회합니다."
+    )
+    @GetMapping("")
+    ApiResponse<Long> getPoints(
+        @Schema(name = "X-USER-ID", description = "조회할 회원의 ID", example = "gdh5866")
+        String userId
+    );
+
+    /*@Operation(
+            summary = "회원 가입",
+            description = "회원 가입 정보를 입력하여 회원을 등록합니다."
+    )
+    @PostMapping("/")
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+            @RequestBody UserV1Dto.UserRequest userRequest
+    );*/
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,42 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/points")
+public class PointV1Controller implements PointV1ApiSpec {
+
+    private final UserService userService;
+
+    @GetMapping("")
+    @Override
+    public ApiResponse<Long> getPoints(
+        @RequestHeader(value = "X-USER-ID", required = false) String userId
+    ) {
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 헤더가 누락되었습니다.");
+        }
+        Long points = userService.getPoints(userId);
+        if (points == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 ID입니다.");
+        }
+        return ApiResponse.success(points);
+    }
+
+    /*@PostMapping("")
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> signUp(
+            @RequestBody UserV1Dto.UserRequest userRequest
+    ) {
+        UserCommand.Create command = userRequest.toCommand();
+        UserInfo userInfo = userService.signUp(command);
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
+        return ApiResponse.success(response);
+    }*/
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -14,7 +14,7 @@ public class PointV1Controller implements PointV1ApiSpec {
 
     private final UserService userService;
 
-    @GetMapping("")
+    @GetMapping
     @Override
     public ApiResponse<Long> getPoints(
         @RequestHeader(value = "X-USER-ID", required = false) String userId

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -29,14 +29,17 @@ public class PointV1Controller implements PointV1ApiSpec {
         return ApiResponse.success(points);
     }
 
-    /*@PostMapping("")
+    @PostMapping("/charge")
     @Override
-    public ApiResponse<UserV1Dto.UserResponse> signUp(
-            @RequestBody UserV1Dto.UserRequest userRequest
+    public ApiResponse<Long> chargePoint(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
+            @RequestBody PointV1Dto.PointChargeRequest request
     ) {
-        UserCommand.Create command = userRequest.toCommand();
-        UserInfo userInfo = userService.signUp(command);
-        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
-        return ApiResponse.success(response);
-    }*/
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 헤더가 누락되었습니다.");
+        }
+
+        Long points = userService.chargePoints(userId, request.amount());
+        return ApiResponse.success(points);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,7 @@
+package com.loopers.interfaces.api.point;
+
+public class PointV1Dto {
+    public record PointChargeRequest(Long amount) {
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "회원 관련 API 입니다.")
+public interface UserV1ApiSpec {
+
+    @Operation(
+        summary = "회원 정보 조회",
+        description = "userId를 이용하여 회원 정보를 조회합니다."
+    )
+    ApiResponse<UserV1Dto.UserResponse> getUser(
+        @Schema(name = "userId", description = "조회할 회원의 ID", example = "gdh5866")
+        String userId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -4,6 +4,8 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User V1 API", description = "회원 관련 API 입니다.")
 public interface UserV1ApiSpec {
@@ -15,5 +17,10 @@ public interface UserV1ApiSpec {
     ApiResponse<UserV1Dto.UserResponse> getUser(
         @Schema(name = "userId", description = "조회할 회원의 ID", example = "gdh5866")
         String userId
+    );
+
+    @PostMapping("")
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+            @RequestBody UserV1Dto.UserRequest userRequest
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -12,13 +13,18 @@ public interface UserV1ApiSpec {
 
     @Operation(
         summary = "회원 정보 조회",
-        description = "userId를 이용하여 회원 정보를 조회합니다."
+        description = "X-USER-ID 헤더를 통해 회원 정보를 조회합니다."
     )
+    @GetMapping("/me")
     ApiResponse<UserV1Dto.UserResponse> getUser(
-        @Schema(name = "userId", description = "조회할 회원의 ID", example = "gdh5866")
+        @Schema(name = "X-USER-ID", description = "조회할 회원의 ID", example = "gdh5866")
         String userId
     );
 
+    @Operation(
+            summary = "회원 가입",
+            description = "회원 가입 정보를 입력하여 회원을 등록합니다."
+    )
     @PostMapping("")
     ApiResponse<UserV1Dto.UserResponse> signUp(
             @RequestBody UserV1Dto.UserRequest userRequest

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,13 +1,11 @@
 package com.loopers.interfaces.api.user;
 
-import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.UserCommand;
+import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -16,13 +14,24 @@ public class UserV1Controller implements UserV1ApiSpec {
 
     private final UserService userService;
 
-    @GetMapping("/{userId}")
+    @GetMapping("/me")
     @Override
     public ApiResponse<UserV1Dto.UserResponse> getUser(
-        @PathVariable(value = "userId") String userId
+        @RequestHeader(value = "X-USER-ID") String userId
     ) {
         UserInfo info = userService.getUserInfo(userId);
         UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(info);
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("")
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> signUp(
+            @RequestBody UserV1Dto.UserRequest userRequest
+    ) {
+        UserCommand.Create command = userRequest.toCommand();
+        UserInfo userInfo = userService.signUp(command);
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(userInfo);
         return ApiResponse.success(response);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1Controller implements UserV1ApiSpec {
+
+    private final UserService userService;
+
+    @GetMapping("/{userId}")
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> getUser(
+        @PathVariable(value = "userId") String userId
+    ) {
+        UserInfo info = userService.getUserInfo(userId);
+        UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(info);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -22,9 +22,7 @@ public class UserV1Controller implements UserV1ApiSpec {
         @RequestHeader(value = "X-USER-ID") String userId
     ) {
         UserInfo info = userService.getUserInfo(userId);
-        if (info == null) {
-            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 ID입니다.");
-        }
+
         UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(info);
         return ApiResponse.success(response);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -4,6 +4,8 @@ import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +22,9 @@ public class UserV1Controller implements UserV1ApiSpec {
         @RequestHeader(value = "X-USER-ID") String userId
     ) {
         UserInfo info = userService.getUserInfo(userId);
+        if (info == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 ID입니다.");
+        }
         UserV1Dto.UserResponse response = UserV1Dto.UserResponse.from(info);
         return ApiResponse.success(response);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserInfo;
+
+public class UserV1Dto {
+    public record UserRequest(String userId, String gender, String birthDate, String email) {
+
+    }
+    public record UserResponse(String userId, String gender, String birthDate, String email) {
+        public static UserResponse from(UserInfo info) {
+            return new UserResponse(
+                    info.userId(),
+                    info.gender(),
+                    info.birthDate(),
+                    info.email()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,10 +1,13 @@
 package com.loopers.interfaces.api.user;
 
-import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.UserCommand;
+import com.loopers.domain.user.UserInfo;
 
 public class UserV1Dto {
     public record UserRequest(String userId, String gender, String birthDate, String email) {
-
+        public UserCommand.Create toCommand (){
+            return new UserCommand.Create(userId, gender, birthDate, email);
+        }
     }
     public record UserResponse(String userId, String gender, String birthDate, String email) {
         public static UserResponse from(UserInfo info) {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/PointTest.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PointTest {
+    @DisplayName("포인트 충전 단위 테스트")
+    @Nested
+    class PointCharge {
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @Test
+        void failToCharge_whenChargeAmountIsZeroOrNegative() {
+            // arrange
+            User user = new User("gdh5866", "F", "1995-06-11", "donghee@test.com");
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                user.addPoint(0L);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getMessage()).contains("0 이하의 정수");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/PointTest.java
@@ -26,7 +26,7 @@ class PointTest {
 
             // assert
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-            assertThat(result.getMessage()).contains("0 이하의 정수");
+            assertThat(result.getMessage()).contains("충전할 포인트는 0보다 커야 합니다.");
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/PointTest.java
@@ -21,7 +21,7 @@ class PointTest {
 
             // act
             CoreException result = assertThrows(CoreException.class, () -> {
-                user.addPoint(0L);
+                user.chargePoint(0L);
             });
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.loopers.domain.user;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class USerServiceIntegrationTest {
+    @Autowired
+    private UserService userService;
+
+    @MockitoSpyBean
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("회원 가입 통합 테스트")
+    @Nested
+    class SignUp {
+        @DisplayName("회원 가입시 User 저장이 수행 된다.")
+        @Test
+        void saveUser_whenSignUp() {
+            // arrange
+            UserV1Dto.UserRequest request = new UserV1Dto.UserRequest(
+                    "gdh5866",
+                    "F",
+                    "1995-06-11",
+                    "donghee@test.com"
+            );
+
+            // act
+            userService.signUp(request);
+
+            // assert
+            verify(userJpaRepository, times(1)).save(any(User.class));
+        }
+
+        @DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
+        @Test
+        void failToSignUp_whenTryToSignUpExistedID() {
+            // arrange
+            String sameId = "gdh5866";
+
+            UserV1Dto.UserRequest firstRequest = new UserV1Dto.UserRequest(
+                    sameId,
+                    "F",
+                    "1995-06-11",
+                    "donghee@test.com"
+            );
+
+            // ID만 같고, 나머지 요소는 다른 두 번째 요청 (ID 중복 시 실패 한다는 것을 더 정확하게 테스트하기 위함)
+            UserV1Dto.UserRequest secondRequest = new UserV1Dto.UserRequest(
+                    sameId,
+                    "M",
+                    "2000-01-01",
+                    "another@mail.com"
+            );
+
+            // 사전 저장
+            userService.signUp(firstRequest);
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                userService.signUp(secondRequest);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+            assertThat(result.getMessage()).contains("이미 가입된 ID");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SpringBootTest
-class USerServiceIntegrationTest {
+class UserServiceIntegrationTest {
     @Autowired
     private UserService userService;
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -168,4 +168,25 @@ class USerServiceIntegrationTest {
         }
 
     }
+
+    @DisplayName("포인트 충전 통합 테스트")
+    @Nested
+    class PointCharge {
+        @DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
+        @Test
+        void failToCharge_whenUserDoesNotExist() {
+            // arrange
+            String unSavedId = "somebody";
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                userService.chargePoints(unSavedId, 1000L);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+            assertThat(result.getMessage()).contains("ID");
+        }
+
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -57,7 +57,7 @@ class USerServiceIntegrationTest {
 
         @DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
         @Test
-        void failToSignUp_whenTryToSignUpExistedID() {
+        void failToSignUp_whenTryToSignUpSavedID() {
             // arrange
             String sameId = "gdh5866";
 
@@ -93,16 +93,14 @@ class USerServiceIntegrationTest {
     @DisplayName("내 정보 조회 통합 테스트")
     @Nested
     class InfoCheck {
-
-        private final String userId = "gdh5866";
-        private final String gender = "F";
-        private final String birthDate = "1995-06-11";
-        private final String email = "donghee@test.com";
-
         @DisplayName("해당 ID의 회원이 존재할 경우, 회원 정보가 반환된다.")
         @Test
         void returnUserInfo_whenUserExists() {
             // arrange
+            String userId = "gdh5866";
+            String gender = "F";
+            String birthDate = "1995-06-11";
+            String email = "donghee@test.com";
             UserCommand.Create command = new UserCommand.Create(userId, gender, birthDate, email);
             userService.signUp(command);
 
@@ -116,5 +114,20 @@ class USerServiceIntegrationTest {
             assertThat(userInfo.birthDate()).isEqualTo(birthDate);
             assertThat(userInfo.email()).isEqualTo(email);
         }
+
+
+        @DisplayName("해당 ID의 회원이 존재하지 않을 경우, null이 반환된다.")
+        @Test
+        void returnNull_whenUserDoesNotExist() {
+            // arrange
+            String unSavedId = "somebody";
+
+            // act
+            UserInfo userInfo = userService.getUserInfo(unSavedId);
+
+            // assert
+            assertThat(userInfo).isNull();
+        }
+
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -89,4 +89,32 @@ class USerServiceIntegrationTest {
             assertThat(result.getMessage()).contains("이미 가입된 ID");
         }
     }
+
+    @DisplayName("내 정보 조회 통합 테스트")
+    @Nested
+    class InfoCheck {
+
+        private final String userId = "gdh5866";
+        private final String gender = "F";
+        private final String birthDate = "1995-06-11";
+        private final String email = "donghee@test.com";
+
+        @DisplayName("해당 ID의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnUserInfo_whenUserExists() {
+            // arrange
+            UserCommand.Create command = new UserCommand.Create(userId, gender, birthDate, email);
+            userService.signUp(command);
+
+            // act
+            UserInfo userInfo = userService.getUserInfo(userId);
+
+            // assert
+            assertThat(userInfo).isNotNull();
+            assertThat(userInfo.userId()).isEqualTo(userId);
+            assertThat(userInfo.gender()).isEqualTo(gender);
+            assertThat(userInfo.birthDate()).isEqualTo(birthDate);
+            assertThat(userInfo.email()).isEqualTo(email);
+        }
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.user;
 
 import com.loopers.infrastructure.user.UserJpaRepository;
-import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -42,7 +41,7 @@ class USerServiceIntegrationTest {
         @Test
         void saveUser_whenSignUp() {
             // arrange
-            UserV1Dto.UserRequest request = new UserV1Dto.UserRequest(
+            UserCommand.Create command = new UserCommand.Create(
                     "gdh5866",
                     "F",
                     "1995-06-11",
@@ -50,7 +49,7 @@ class USerServiceIntegrationTest {
             );
 
             // act
-            userService.signUp(request);
+            userService.signUp(command);
 
             // assert
             verify(userJpaRepository, times(1)).save(any(User.class));
@@ -62,27 +61,27 @@ class USerServiceIntegrationTest {
             // arrange
             String sameId = "gdh5866";
 
-            UserV1Dto.UserRequest firstRequest = new UserV1Dto.UserRequest(
+            UserCommand.Create firstCommand = new UserCommand.Create(
                     sameId,
                     "F",
                     "1995-06-11",
                     "donghee@test.com"
             );
 
+            // 사전 저장
+            userService.signUp(firstCommand);
+
             // ID만 같고, 나머지 요소는 다른 두 번째 요청 (ID 중복 시 실패 한다는 것을 더 정확하게 테스트하기 위함)
-            UserV1Dto.UserRequest secondRequest = new UserV1Dto.UserRequest(
+            UserCommand.Create secondCommand = new UserCommand.Create (
                     sameId,
                     "M",
                     "2000-01-01",
                     "another@mail.com"
             );
 
-            // 사전 저장
-            userService.signUp(firstRequest);
-
             // act
             CoreException result = assertThrows(CoreException.class, () -> {
-                userService.signUp(secondRequest);
+                userService.signUp(secondCommand);
             });
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -130,4 +130,42 @@ class USerServiceIntegrationTest {
         }
 
     }
+
+    @DisplayName("포인트 조회 통합 테스트")
+    @Nested
+    class PointCheck {
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnsPointsOnHand_whenUserExists() {
+            // arrange
+            String userId = "gdh5866";
+            String gender = "F";
+            String birthDate = "1995-06-11";
+            String email = "donghee@test.com";
+            UserCommand.Create command = new UserCommand.Create(userId, gender, birthDate, email);
+            userService.signUp(command);
+
+            // act
+            Long point = userService.getPoints(userId);
+
+            // assert
+            assertThat(point).isNotNull();
+            assertThat(point).isEqualTo(0L);
+        }
+
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnNull_whenUserDoesNotExist() {
+            // arrange
+            String unSavedId = "somebody";
+
+            // act
+            Long point = userService.getPoints(unSavedId);
+
+            // assert
+            assertThat(point).isNull();
+        }
+
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -116,17 +116,19 @@ class UserServiceIntegrationTest {
         }
 
 
-        @DisplayName("해당 ID의 회원이 존재하지 않을 경우, null이 반환된다.")
+        @DisplayName("해당 ID의 회원이 존재하지 않을 경우, 예외가 발생한다.")
         @Test
         void returnNull_whenUserDoesNotExist() {
             // arrange
             String unSavedId = "somebody";
 
-            // act
-            UserInfo userInfo = userService.getUserInfo(unSavedId);
+            // acT
+            CoreException result = assertThrows(CoreException.class, () -> {
+                userService.getUserInfo(unSavedId);
+            });
 
             // assert
-            assertThat(userInfo).isNull();
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
         }
 
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -90,4 +90,24 @@ class UserTest {
             assertThat(result.getMessage()).contains("생년월일"); // 생년월일 때문에 에러가 발생 했는지 정확하게 확인
         }
     }
+
+    @DisplayName("포인트 충전 단위 테스트")
+    @Nested
+    class PointCharge {
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @Test
+        void failToCharge_whenChargeAmountIsZeroOrNegative() {
+            // arrange
+            User user = new User("gdh5866", "F", "1995-06-11", "donghee@test.com");
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                user.addPoint(0L);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getMessage()).contains("0 이하의 정수");
+        }
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,66 +1,93 @@
 package com.loopers.domain.user;
 
-import com.loopers.domain.example.ExampleModel;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class UserTest {
     @DisplayName("회원 가입 단위 테스트")
     @Nested
     class SignUp {
-        @DisplayName("ID 가 영문 및 숫자 10자 이내 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @DisplayName("ID 가 영문 및 숫자 10자 이내 형식에 맞지 않으면, User 객체 생성에 실패 한다.")
         @Test
         void failToCreateUser_whenIDNotSuitable() {
             // arrange
-            String id = "고동희고동희";
+            String userId = "고동희고동희";
             String gender = "F";
             String birthDate = "1995-06-11";
             String email = "qmdlfakrhf@naver.com";
 
             // act
             CoreException result = assertThrows(CoreException.class, () -> {
-                new User(id, gender, birthDate, email);
+                new User(userId, gender, birthDate, email);
             });
 
             // assert
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getMessage()).contains("ID"); // ID 때문에 에러가 발생 했는지 정확하게 확인
         }
 
-        @DisplayName("제목이 빈칸으로만 이루어져 있으면, BAD_REQUEST 예외가 발생한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "a",                // 유효한 최소 길이 (1자)
+                "abcde",            // 유효한 중간 길이
+                "abcdefghij",       // 유효한 최대 길이 (10자)
+                "user12345",        // 영문/숫자 조합
+                "USERABCDEF",       // 대문자 조합
+                "1234567890"        // 숫자 조합
+        })
+        @DisplayName("유효한 ID로 User 객체 생성 성공 (경계값 포함)")
+        void createUserWithValidId(String validId) {
+            String gender = "F";
+            String birthDate = "1995-06-11";
+            String email = "test@example.com";
+
+            assertDoesNotThrow(() -> new User(validId, gender, birthDate, email));
+        }
+
+        @DisplayName("이메일이 xx@yy.zz 형식에 맞지 않으면, User 객체 생성에 실패 한다.")
         @Test
-        void throwsBadRequestException_whenTitleIsBlank() {
+        void failToCreateUser_whenEmailNotSuitable() {
             // arrange
-            String name = "   ";
+            String userId = "gdh5866";
+            String gender = "F";
+            String birthDate = "1995-06-11";
+            String email = "trashtrash";
 
             // act
             CoreException result = assertThrows(CoreException.class, () -> {
-                new ExampleModel(name, "설명");
+                new User(userId, gender, birthDate, email);
             });
 
             // assert
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getMessage()).contains("이메일"); // 이메일 때문에 에러가 발생 했는지 정확하게 확인
         }
 
-        @DisplayName("설명이 비어있으면, BAD_REQUEST 예외가 발생한다.")
+        @DisplayName("생년월일이 yyyy-MM-dd 형식에 맞지 않으면, User 객체 생성에 실패 한다.")
         @Test
-        void throwsBadRequestException_whenDescriptionIsEmpty() {
+        void failToCreateUser_whenBirthDateNotSuitable() {
             // arrange
-            String description = "";
+            String userId = "gdh5866";
+            String gender = "F";
+            String birthDate = "19950611";
+            String email = "test@email.com";
 
             // act
             CoreException result = assertThrows(CoreException.class, () -> {
-                new ExampleModel("제목", description);
+                new User(userId, gender, birthDate, email);
             });
 
             // assert
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getMessage()).contains("생년월일"); // 생년월일 때문에 에러가 발생 했는지 정확하게 확인
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,0 +1,66 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.example.ExampleModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UserTest {
+    @DisplayName("회원 가입 단위 테스트")
+    @Nested
+    class SignUp {
+        @DisplayName("ID 가 영문 및 숫자 10자 이내 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failToCreateUser_whenIDNotSuitable() {
+            // arrange
+            String id = "고동희고동희";
+            String gender = "F";
+            String birthDate = "1995-06-11";
+            String email = "qmdlfakrhf@naver.com";
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new User(id, gender, birthDate, email);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("제목이 빈칸으로만 이루어져 있으면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwsBadRequestException_whenTitleIsBlank() {
+            // arrange
+            String name = "   ";
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new ExampleModel(name, "설명");
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("설명이 비어있으면, BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwsBadRequestException_whenDescriptionIsEmpty() {
+            // arrange
+            String description = "";
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new ExampleModel("제목", description);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -90,24 +90,4 @@ class UserTest {
             assertThat(result.getMessage()).contains("생년월일"); // 생년월일 때문에 에러가 발생 했는지 정확하게 확인
         }
     }
-
-    @DisplayName("포인트 충전 단위 테스트")
-    @Nested
-    class PointCharge {
-        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
-        @Test
-        void failToCharge_whenChargeAmountIsZeroOrNegative() {
-            // arrange
-            User user = new User("gdh5866", "F", "1995-06-11", "donghee@test.com");
-
-            // act
-            CoreException result = assertThrows(CoreException.class, () -> {
-                user.addPoint(0L);
-            });
-
-            // assert
-            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-            assertThat(result.getMessage()).contains("0 이하의 정수");
-        }
-    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,0 +1,148 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PointV1ApiE2ETest {
+
+    private final TestRestTemplate testRestTemplate;
+    private final UserJpaRepository userJpaRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public PointV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            UserJpaRepository userJpaRepository,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.userJpaRepository = userJpaRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+    private static final String USER_ID = "gdh5866";
+    private static final String GENDER = "F";
+    private static final String BIRTH_DATE = "1995-06-11";
+    private static final String EMAIL = "donghee@test.com";
+    private static final String SIGN_UP_ENDPOINT = "/api/v1/users";
+    private static final String POINT_CHECK_ENDPOINT = "/api/v1/points";
+    private static final String POINT_CHARGE_ENDPOINT = "/api/v1/points/charge";
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private UserV1Dto.UserRequest defaultUserRequest() {
+        return new UserV1Dto.UserRequest(USER_ID, GENDER, BIRTH_DATE, EMAIL);
+    }
+    @DisplayName("GET /api/v1/points")
+    @Nested
+    class PointCheck {
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsPoints_whenPointCheckIsSuccessful() {
+            // arrange
+            testRestTemplate.postForEntity(SIGN_UP_ENDPOINT, defaultUserRequest(), Void.class);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", USER_ID);
+            HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(POINT_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data()).isEqualTo(0L)
+            );
+        }
+
+        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returns404BadRequest_whenXUSERIDDoesNotExist() {
+            // arrange
+            HttpEntity<Void> httpEntity = new HttpEntity<>(null);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(POINT_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
+            );
+        }
+    }
+
+    @DisplayName("POST /api/v1/points/charge")
+    @Nested
+    class PointCharge {
+        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+        @Test
+        void returnsTotalPoints_whenUserAddsPoints1000() {
+            // arrange
+            testRestTemplate.postForEntity(SIGN_UP_ENDPOINT, defaultUserRequest(), Void.class);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", USER_ID);
+            PointV1Dto.PointChargeRequest request = new PointV1Dto.PointChargeRequest(1000L);
+            HttpEntity<PointV1Dto.PointChargeRequest> httpEntity = new HttpEntity<>(request, headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(POINT_CHARGE_ENDPOINT, HttpMethod.POST, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data()).isEqualTo(1000L)
+            );
+        }
+
+        @DisplayName("존재하지 않는 유저로 요청할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void returns404NotFound_whenUserDoesNotExist() {
+            // arrange
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", USER_ID);
+            PointV1Dto.PointChargeRequest request = new PointV1Dto.PointChargeRequest(1000L);
+            HttpEntity<PointV1Dto.PointChargeRequest> httpEntity = new HttpEntity<>(request, headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(POINT_CHARGE_ENDPOINT, HttpMethod.POST, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
+        }
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -41,6 +41,7 @@ public class UserV1ApiE2ETest {
     private static final String EMAIL = "donghee@test.com";
     private static final String SIGN_UP_ENDPOINT = "/api/v1/users";
     private static final String INFO_CHECK_ENDPOINT = "/api/v1/users/me";
+    private static final String POINT_CHECK_ENDPOINT = "/api/v1/points";
 
     @AfterEach
     void tearDown() {
@@ -142,6 +143,51 @@ public class UserV1ApiE2ETest {
             assertAll(
                     () -> assertTrue(response.getStatusCode().is4xxClientError()),
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
+        }
+
+    }
+
+    @DisplayName("GET /api/v1/points")
+    @Nested
+    class PointCheck {
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsPoints_whenPointCheckIsSuccessful() {
+            // arrange
+            testRestTemplate.postForEntity(SIGN_UP_ENDPOINT, defaultUserRequest(), Void.class);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", USER_ID);
+            HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(POINT_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data()).isEqualTo(0L)
+            );
+        }
+
+        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returns404BadRequest_whenXUSERIDDoesNotExist() {
+            // arrange
+            HttpEntity<Void> httpEntity = new HttpEntity<>(null);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Long>> response =
+                    testRestTemplate.exchange(POINT_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
             );
         }
 

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,91 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import io.swagger.v3.oas.models.PathItem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class UserV1ApiE2ETest {
+
+    private final TestRestTemplate testRestTemplate;
+    private final UserJpaRepository userJpaRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public UserV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            UserJpaRepository userJpaRepository,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.userJpaRepository = userJpaRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class SignUp {
+        private static final String ENDPOINT = "/api/v1/users";
+
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserInfo_whenSignUpIsSuccessful() {
+            // arrange
+            var request = new UserV1Dto.UserRequest(
+                    "gdh5866",        // id
+                    "female",                // gender
+                    "1995-06-11",            // birthDate
+                    "donghee@shinsegae.com"  // email
+            );
+
+            HttpEntity<UserV1Dto.UserRequest> httpEntity = new HttpEntity<>(request);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data().userId()).isEqualTo("gdh5866"),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo("donghee@shinsegae.com")
+            );
+
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenGenderIsMissing() {
+            // arrange
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>>() {};
+            // assert
+
+        }
+
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -11,10 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -38,60 +35,57 @@ public class UserV1ApiE2ETest {
         this.databaseCleanUp = databaseCleanUp;
     }
 
+    private static final String USER_ID = "gdh5866";
+    private static final String GENDER = "F";
+    private static final String BIRTH_DATE = "1995-06-11";
+    private static final String EMAIL = "donghee@test.com";
+    private static final String SIGN_UP_ENDPOINT = "/api/v1/users";
+    private static final String INFO_CHECK_ENDPOINT = "/api/v1/users/me";
+
     @AfterEach
     void tearDown() {
         databaseCleanUp.truncateAllTables();
     }
 
+    private UserV1Dto.UserRequest defaultUserRequest() {
+        return new UserV1Dto.UserRequest(USER_ID, GENDER, BIRTH_DATE, EMAIL);
+    }
+
     @DisplayName("POST /api/v1/users")
     @Nested
     class SignUp {
-        private static final String ENDPOINT = "/api/v1/users";
-
         @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
         @Test
         void returnsUserInfo_whenSignUpIsSuccessful() {
             // arrange
-            var request = new UserV1Dto.UserRequest(
-                    "gdh5866",        // id
-                    "F",                     // gender
-                    "1995-06-11",            // birthDate
-                    "donghee@shinsegae.com"  // email
-            );
-
-            HttpEntity<UserV1Dto.UserRequest> httpEntity = new HttpEntity<>(request);
+            HttpEntity<UserV1Dto.UserRequest> httpEntity = new HttpEntity<>(defaultUserRequest());
 
             // act
             ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
-                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, httpEntity, responseType);
+                    testRestTemplate.exchange(SIGN_UP_ENDPOINT, HttpMethod.POST, httpEntity, responseType);
 
             // assert
             assertAll(
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                    () -> assertThat(response.getBody().data().userId()).isEqualTo("gdh5866"),
-                    () -> assertThat(response.getBody().data().gender()).isEqualTo("F"),
-                    () -> assertThat(response.getBody().data().birthDate()).isEqualTo("1995-06-11"),
-                    () -> assertThat(response.getBody().data().email()).isEqualTo("donghee@shinsegae.com")
+                    () -> assertThat(response.getBody().data().userId()).isEqualTo(USER_ID),
+                    () -> assertThat(response.getBody().data().gender()).isEqualTo(GENDER),
+                    () -> assertThat(response.getBody().data().birthDate()).isEqualTo(BIRTH_DATE),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(EMAIL)
             );
         }
 
         @DisplayName("회원 가입 시에 성별이 없을 경우, 400 Bad Request 응답을 반환한다.")
         @Test
         void returnsBadRequest_whenGenderIsMissing() {
-            var request = new UserV1Dto.UserRequest(
-                    "gdh5866",        // id
-                    "",                      // gender
-                    "1995-06-11",            // birthDate
-                    "donghee@shinsegae.com"  // email
-            );
-
+            // arrange
+            var request = new UserV1Dto.UserRequest(USER_ID, "", BIRTH_DATE, EMAIL);
             HttpEntity<UserV1Dto.UserRequest> httpEntity = new HttpEntity<>(request);
 
             // act
             ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
-                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, httpEntity, responseType);
+                    testRestTemplate.exchange(SIGN_UP_ENDPOINT, HttpMethod.POST, httpEntity, responseType);
 
             // assert
             assertAll(
@@ -99,6 +93,56 @@ public class UserV1ApiE2ETest {
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
             );
 
+        }
+
+    }
+
+    @DisplayName("GET /api/v1/users/me")
+    @Nested
+    class InfoCheck {
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserInfo_whenInfoCheckIsSuccessful() {
+            // arrange
+            testRestTemplate.postForEntity(SIGN_UP_ENDPOINT, defaultUserRequest(), Void.class);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", USER_ID);
+            HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(INFO_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data().userId()).isEqualTo(USER_ID),
+                    () -> assertThat(response.getBody().data().gender()).isEqualTo(GENDER),
+                    () -> assertThat(response.getBody().data().birthDate()).isEqualTo(BIRTH_DATE),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(EMAIL)
+            );
+        }
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void returns404NotFound_whenIDDoesNotExist() {
+            // arrange
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", USER_ID);
+            HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(INFO_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
         }
 
     }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -42,8 +42,6 @@ public class UserV1ApiE2ETest {
     private static final String EMAIL = "donghee@test.com";
     private static final String SIGN_UP_ENDPOINT = "/api/v1/users";
     private static final String INFO_CHECK_ENDPOINT = "/api/v1/users/me";
-    private static final String POINT_CHECK_ENDPOINT = "/api/v1/points";
-    private static final String POINT_CHARGE_ENDPOINT = "/api/v1/points/charge";
 
     @AfterEach
     void tearDown() {
@@ -140,101 +138,6 @@ public class UserV1ApiE2ETest {
             ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
                     testRestTemplate.exchange(INFO_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
-
-            // assert
-            assertAll(
-                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
-                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
-            );
-        }
-
-    }
-
-    @DisplayName("GET /api/v1/points")
-    @Nested
-    class PointCheck {
-        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
-        @Test
-        void returnsPoints_whenPointCheckIsSuccessful() {
-            // arrange
-            testRestTemplate.postForEntity(SIGN_UP_ENDPOINT, defaultUserRequest(), Void.class);
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("X-USER-ID", USER_ID);
-            HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {
-            };
-            ResponseEntity<ApiResponse<Long>> response =
-                    testRestTemplate.exchange(POINT_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
-
-            // assert
-            assertAll(
-                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                    () -> assertThat(response.getBody().data()).isEqualTo(0L)
-            );
-        }
-
-        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
-        @Test
-        void returns404BadRequest_whenXUSERIDDoesNotExist() {
-            // arrange
-            HttpEntity<Void> httpEntity = new HttpEntity<>(null);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {
-            };
-            ResponseEntity<ApiResponse<Long>> response =
-                    testRestTemplate.exchange(POINT_CHECK_ENDPOINT, HttpMethod.GET, httpEntity, responseType);
-
-            // assert
-            assertAll(
-                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
-                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST)
-            );
-        }
-    }
-
-    @DisplayName("POST /api/v1/points/charge")
-    @Nested
-    class PointCharge {
-        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
-        @Test
-        void returnsTotalPoints_whenUserAddsPoints1000() {
-            // arrange
-            testRestTemplate.postForEntity(SIGN_UP_ENDPOINT, defaultUserRequest(), Void.class);
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("X-USER-ID", USER_ID);
-            PointV1Dto.PointChargeRequest request = new PointV1Dto.PointChargeRequest(1000L);
-            HttpEntity<PointV1Dto.PointChargeRequest> httpEntity = new HttpEntity<>(request, headers);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
-            ResponseEntity<ApiResponse<Long>> response =
-                    testRestTemplate.exchange(POINT_CHARGE_ENDPOINT, HttpMethod.POST, httpEntity, responseType);
-
-            // assert
-            assertAll(
-                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
-                    () -> assertThat(response.getBody().data()).isEqualTo(1000L)
-            );
-        }
-
-        @DisplayName("존재하지 않는 유저로 요청할 경우, 404 Not Found 응답을 반환한다.")
-        @Test
-        void returns404NotFound_whenUserDoesNotExist() {
-            // arrange
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("X-USER-ID", USER_ID);
-            PointV1Dto.PointChargeRequest request = new PointV1Dto.PointChargeRequest(1000L);
-            HttpEntity<PointV1Dto.PointChargeRequest> httpEntity = new HttpEntity<>(request, headers);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<Long>> responseType = new ParameterizedTypeReference<>() {};
-            ResponseEntity<ApiResponse<Long>> response =
-                    testRestTemplate.exchange(POINT_CHARGE_ENDPOINT, HttpMethod.POST, httpEntity, responseType);
 
             // assert
             assertAll(

--- a/modules/jpa/build.gradle.kts
+++ b/modules/jpa/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     // querydsl
     api("com.querydsl:querydsl-jpa::jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     // jdbc-mysql
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "loopers-java-spring-template"
+rootProject.name = "loopers-donghee"
 
 include(
     ":apps:commerce-api",


### PR DESCRIPTION
## 📌 Summary
   - User 관련 API 테스트 코드 작성
   - User 관련 API 구현 (회원 가입/내 정보 조회)
   - Point 관련 API 테스트 코드 작성
   - Point 관련 API 구현 (포인트 조회/포인트 충전)
 
## 💬 Review Points
- ID 중복 회원가입 테스트의 실패 원인 단정에 대한 고민
  - [회원 가입 통합테스트](https://github.com/kodonghee/loopers-e-commerce/pull/1/commits/60e14af07dcc55c52960cd446a9b6693f6dfe904#diff-e7b880b8679f22fb54979d3312f22f3ce057c95674b8daa16db79f27c5833754)
  - 단순히 동일한 ID로 두 번 회원 가입을 시도하면 실패하는 건 맞지만 정말 "ID 중복" 때문인지, 아니면 다른 필드 차이로 인한 문제는 아닌지 헷갈릴 수 있음.
  - ID 외의 나머지 필드를 모두 다르게 한 채로 테스트를 구성함.
  - 실패 사유가 ID 중복임을 명확하게 증명할 수 있는 다른 방법에 대한 궁금증 존재.
- 포인트 도메인을 `Long`이 아닌 `Point` 객체로 분리한 이유
  - User는 Entity로, Point는 VO로 만들고 `@Embedded`를 통해 User 안에 넣음.
  - 포인트는 단순한 숫자가 아니라 충전, 차감, 이벤트 등 다양한 동작이 붙을 수 있는 개념이라 별도의 객체로 만듬.
  - 하지만 여전히 User에 종속된 개념으로 이해하여 `@Embedded`로 User안에 포함함.
- Repository **Spy** 대상 고민
  - UserRepository: 인터페이스로 도메인 상위 계층에서 사용됨.
  - UserRepositoryImpl: 이를 구현한 클래스
  - UserJpaRepository: Spring Data JPA가 자동으로 구현해주는 JPA 인터페이스
  - DB에 직접 접근하여 회원 정보를 저장하는 부분이 동작하는지 확인하고 싶었기 때문에 UserJpaRepository를 Spy 대상으로 선택

## ✅ Checklist
    [✔️] 테스트는 모두 통과해야 하며, @Test 기반으로 명시적으로 작성
    [✔️] 각 테스트는 테스트 명/설명/입력/예상 결과가 분명해야 함
    [✔️] E2E 테스트는 실제 HTTP 요청을 통해 흐름을 검증할 것

## 📎 References
  - [테스트 더블](https://brunch.co.kr/@tilltue/55)
  - [Embeddable, Embedded](https://choi-records.tistory.com/entry/JPA-%EA%B0%92-%ED%83%80%EC%9E%85Embeddable-Embedded)