### PR TITLE
[round-9] 구현 코드 제출 - 고동희

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     implementation(project(":modules:redis"))
     implementation(project(":modules:kafka"))
     implementation(project(":modules:common-events"))
+    implementation(project(":modules:common-support"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -32,10 +32,6 @@ public class LikeFacade {
     private final ProductLikeSummaryRepository productLikeSummaryRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Caching(evict = {
-            @CacheEvict(cacheNames = CACHE_PRODUCT_DETAIL, key = "#criteria.productId()", condition = "#result == true"),
-            @CacheEvict(cacheNames = CACHE_PRODUCT_LIST,   allEntries = true,           condition = "#result == true")
-    })
     @Transactional(rollbackFor = Exception.class)
     public boolean likeProduct(LikeCriteria criteria) {
         Like like = toLike(criteria);
@@ -53,10 +49,6 @@ public class LikeFacade {
         }
     }
 
-    @Caching(evict = {
-            @CacheEvict(cacheNames = CACHE_PRODUCT_DETAIL, key = "#criteria.productId()", condition = "#result == true"),
-            @CacheEvict(cacheNames = CACHE_PRODUCT_LIST,   allEntries = true,           condition = "#result == true")
-    })
     @Transactional(rollbackFor = Exception.class)
     public boolean cancelLikeProduct(LikeCriteria criteria) {
         UserId userId = new UserId(criteria.userId());

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderExternalEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderExternalEventHandler.java
@@ -1,0 +1,38 @@
+package com.loopers.application.order;
+
+import com.loopers.application.event.MessagePublisher;
+import com.loopers.domain.like.event.LikeCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.events.like.LikeChangedEvent;
+import com.loopers.events.order.OrderPlacedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderExternalEventHandler {
+
+    private final MessagePublisher messagePublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(OrderCreatedEvent event) {
+
+        var itemDtos = event.items().stream()
+                .map(i -> new OrderPlacedEvent.OrderItemDto(i.getProductId(), i.getQuantity(), i.getPrice()))
+                .toList();
+
+        OrderPlacedEvent externalEvent = OrderPlacedEvent.of(
+                event.orderId(),
+                event.userId(),
+                event.totalAmount(),
+                itemDtos
+        );
+
+        log.info("Publishing OrderPlacedEvent: {}", externalEvent);
+        messagePublisher.publish(externalEvent);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderService.java
@@ -55,7 +55,7 @@ public class OrderService {
                 order.getOrderId(),
                 order.getUserId(),
                 order.getTotalAmount(),
-                productIds
+                order.getOrderItems()
         ));
         return OrderMapper.fromOrder(order);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -5,12 +5,14 @@ import com.loopers.domain.brand.BrandReader;
 import com.loopers.domain.like.ProductLikeSummary;
 import com.loopers.domain.like.ProductLikeSummaryRepository;
 import com.loopers.domain.product.*;
+import com.loopers.domain.ranking.RankingRepository;
 import com.loopers.infrastructure.product.ProductListCache;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.loopers.config.redis.RedisCacheConfig.CACHE_PRODUCT_LIST;
@@ -20,6 +22,7 @@ import static com.loopers.config.redis.RedisCacheConfig.CACHE_PRODUCT_LIST;
 public class ProductFacade {
 
     private final ProductRepository productRepository;
+    private final RankingRepository rankingRepository;
     private final BrandReader brandReader;
     private final ProductLikeSummaryRepository productLikeSummaryRepository;
     private final ProductListCache productListCache;
@@ -64,6 +67,9 @@ public class ProductFacade {
         Long likeCount = productLikeSummaryRepository.findByProductId(productId)
                 .map(ProductLikeSummary::getLikeCount)
                 .orElse(0L);
-        return ProductMapper.fromProduct(product, brandName, likeCount);
+
+        Long rank = rankingRepository.getRank(LocalDate.now(), productId.toString());
+
+        return ProductMapper.fromProduct(product, brandName, likeCount, rank);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -15,8 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.loopers.config.redis.RedisCacheConfig.CACHE_PRODUCT_LIST;
-
 @RequiredArgsConstructor
 @Service
 public class ProductFacade {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductMapper.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductMapper.java
@@ -19,6 +19,18 @@ public class ProductMapper {
                 likeCount);
     }
 
+    public static ProductResult fromProduct(Product product, String brandName, Long likeCount, Long rank) {
+        return new ProductResult(
+                product.getId(),
+                product.getName(),
+                product.getStock().getValue(),
+                product.getPrice().getAmount(),
+                brandName,
+                likeCount,
+                rank
+        );
+    }
+
     public static ProductResult from(ProductListView v) {
         return new ProductResult(
                 v.getId(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -2,7 +2,22 @@ package com.loopers.application.product;
 
 import java.math.BigDecimal;
 
-public record ProductResult(Long productId, String name, int stock, BigDecimal price, String brandName, Long likeCount) {
+public record ProductResult(
+        Long productId,
+        String name,
+        int stock,
+        BigDecimal price,
+        String brandName,
+        Long likeCount,
+        Long rank
+) {
 
+    public ProductResult(Long productId, String name, int stock, BigDecimal price, String brandName, Long likeCount) {
+        this(productId, name, stock, price, brandName, likeCount, null);
+    }
+
+    public ProductResult withRank(Long rank) {
+        return new ProductResult(productId, name, stock, price, brandName, likeCount, rank);
+    }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -1,0 +1,48 @@
+package com.loopers.application.ranking;
+
+import com.loopers.application.product.ProductMapper;
+import com.loopers.application.product.ProductResult;
+import com.loopers.domain.brand.BrandReader;
+import com.loopers.domain.like.ProductLikeSummary;
+import com.loopers.domain.like.ProductLikeSummaryRepository;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+    private final ProductRepository productRepository;
+    private final BrandReader brandReader;
+    private final ProductLikeSummaryRepository likeSummaryRepository;
+
+    public List<ProductResult> getTopProducts(LocalDate date, int page, int size) {
+        int start = (page - 1) * size;
+        int end = start + size - 1;
+
+        List<String> productIds = rankingRepository.getTopProducts(date, start, end);
+        return productRepository.findAllById(
+                        productIds.stream().map(Long::valueOf).toList()
+                ).stream()
+                .map(product -> {
+                    String brandName = brandReader.getBrandName(product.getBrandId());
+                    Long likeCount = likeSummaryRepository.findByProductId(product.getId())
+                            .map(ProductLikeSummary::getLikeCount)
+                            .orElse(0L);
+                    Long rank = rankingRepository.getRank(date, product.getId().toString());
+
+                    return ProductMapper.fromProduct(product, brandName, likeCount, rank);
+                })
+                .toList();
+    }
+
+    public Long getProductRank(LocalDate date, Long productId) {
+        return rankingRepository.getRank(date, productId.toString());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.order.event;
 
+import com.loopers.domain.order.OrderItem;
+
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -7,9 +9,9 @@ public record OrderCreatedEvent(
         String orderId,
         String userId,
         BigDecimal totalAmount,
-        List<Long> productIds
+        List<OrderItem> items
 ) {
-    public static OrderCreatedEvent of(String orderId, String userId, BigDecimal totalAmount, List<Long> productIds) {
-        return new OrderCreatedEvent(orderId, userId, totalAmount, productIds);
+    public static OrderCreatedEvent of(String orderId, String userId, BigDecimal totalAmount, List<OrderItem> items) {
+        return new OrderCreatedEvent(orderId, userId, totalAmount, items);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface RankingRepository {
-    void incrementScore(LocalDate date, String productId, double score);
     List<String> getTopProducts(LocalDate date, int start, int end);
     Long getRank(LocalDate date, String productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RankingRepository {
+    void incrementScore(LocalDate date, String productId, double score);
+    List<String> getTopProducts(LocalDate date, int start, int end);
+    Long getRank(LocalDate date, String productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/KafkaMessagePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/KafkaMessagePublisher.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.kafka;
 
 import com.loopers.application.event.MessagePublisher;
 import com.loopers.events.like.LikeChangedEvent;
+import com.loopers.events.order.OrderPlacedEvent;
 import com.loopers.events.stock.StockAdjustedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,8 @@ public class KafkaMessagePublisher implements MessagePublisher {
             return "like-events";
         } else if (event instanceof StockAdjustedEvent) {
             return "stock-events";
+        } else if (event instanceof OrderPlacedEvent) {
+            return "order-events";
         }
 
         // TODO: 다른 이벤트 매핑 필요 시 추가
@@ -41,6 +44,9 @@ public class KafkaMessagePublisher implements MessagePublisher {
         }
         if (event instanceof StockAdjustedEvent stockEvent) {
             return String.valueOf(stockEvent.productId());
+        }
+        if (event instanceof OrderPlacedEvent orderEvent) {
+            return orderEvent.orderId();
         }
         return null;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/KafkaMessagePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/KafkaMessagePublisher.java
@@ -25,12 +25,14 @@ public class KafkaMessagePublisher implements MessagePublisher {
     }
 
     private String resolveTopic(Object event) {
-        if (event instanceof LikeChangedEvent || event instanceof StockAdjustedEvent) {
-            return "catalog-events";
+        if (event instanceof LikeChangedEvent) {
+            return "like-events";
+        } else if (event instanceof StockAdjustedEvent) {
+            return "stock-events";
         }
 
         // TODO: 다른 이벤트 매핑 필요 시 추가
-        throw new IllegalArgumentException("Unknown event type: " + event.getClass().getName());
+        throw new IllegalArgumentException("Unknown event type: " + event.getClass());
     }
 
     private Object resolveKey(Object event) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRedisRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRedisRepository.java
@@ -9,24 +9,12 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
 public class RankingRedisRepository implements RankingRepository {
 
     private final StringRedisTemplate redisTemplate;
-
-    @Override
-    public void incrementScore(LocalDate date, String productId, double score) {
-        String key = RankingKeyGenerator.dailyKey(date);
-
-        redisTemplate.opsForZSet().incrementScore(key, productId, score);
-
-        if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
-            redisTemplate.expire(key, RankingKeyGenerator.ttlSeconds(), TimeUnit.SECONDS);
-        }
-    }
 
     @Override
     public List<String> getTopProducts(LocalDate date, int start, int end) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRedisRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRedisRepository.java
@@ -1,0 +1,44 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import com.loopers.support.ranking.RankingKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingRedisRepository implements RankingRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void incrementScore(LocalDate date, String productId, double score) {
+        String key = RankingKeyGenerator.dailyKey(date);
+
+        redisTemplate.opsForZSet().incrementScore(key, productId, score);
+
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+            redisTemplate.expire(key, RankingKeyGenerator.ttlSeconds(), TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public List<String> getTopProducts(LocalDate date, int start, int end) {
+        String key = RankingKeyGenerator.dailyKey(date);
+        Set<String> range = redisTemplate.opsForZSet().reverseRange(key, start, end);
+        return range == null ? List.of() : List.copyOf(range);
+    }
+
+    @Override
+    public Long getRank(LocalDate date, String productId) {
+        String key = RankingKeyGenerator.dailyKey(date);
+        Long rank = redisTemplate.opsForZSet().reverseRank(key, productId);
+        return rank == null ? null : rank + 1;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -19,7 +19,7 @@ public interface ProductV1ApiSpec {
         description = "브랜드 ID, 정렬 기준, 페이지 번호, 페이지당 상품 수에 따라 상품 목록을 조회합니다."
     )
     @GetMapping("")
-    ApiResponse<List<ProductV1Dto.ProductResponse>> getProductList(
+    ApiResponse<List<ProductV1Dto.ProductListResponse>> getProductList(
             @Parameter(description = "브랜드 ID (선택)", example = "1")
             @RequestParam(name = "brandId", required = false)
             Long brandId,
@@ -39,7 +39,7 @@ public interface ProductV1ApiSpec {
 
     @Operation(summary = "상품 상세 조회", description = "상품 ID로 상세 정보를 조회합니다.")
     @GetMapping("/{productId}")
-    ApiResponse<ProductV1Dto.ProductResponse> getProductDetail(
+    ApiResponse<ProductV1Dto.ProductDetailResponse> getProductDetail(
             @Parameter(description = "상품 ID", example = "1")
             @PathVariable("productId")
             Long productId

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -19,7 +19,7 @@ public class ProductV1Controller implements ProductV1ApiSpec {
 
     @GetMapping
     @Override
-    public ApiResponse<List<ProductV1Dto.ProductResponse>> getProductList(
+    public ApiResponse<List<ProductV1Dto.ProductListResponse>> getProductList(
             @RequestParam(required = false) Long brandId,
             @RequestParam(defaultValue = "LATEST") ProductSearchCondition.ProductSortType sortType,
             @RequestParam(defaultValue = "0") int page,
@@ -29,8 +29,8 @@ public class ProductV1Controller implements ProductV1ApiSpec {
                 brandId, sortType, page, size
         );
         List<ProductResult> products = productFacade.getProductList(condition);
-        List<ProductV1Dto.ProductResponse> response = products.stream()
-                .map(ProductV1Dto.ProductResponse::from)
+        List<ProductV1Dto.ProductListResponse> response = products.stream()
+                .map(ProductV1Dto.ProductListResponse::from)
                 .toList();
 
         return ApiResponse.success(response);
@@ -38,12 +38,12 @@ public class ProductV1Controller implements ProductV1ApiSpec {
 
     @GetMapping("/{productId}")
     @Override
-    public ApiResponse<ProductV1Dto.ProductResponse> getProductDetail(
+    public ApiResponse<ProductV1Dto.ProductDetailResponse> getProductDetail(
             @Parameter(description = "상품 ID", example = "1")
             @PathVariable("productId") Long productId
     ) {
         ProductResult product = productFacade.getProductDetail(productId);
-        return ApiResponse.success(ProductV1Dto.ProductResponse.from(product));
+        return ApiResponse.success(ProductV1Dto.ProductDetailResponse.from(product));
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -6,7 +6,7 @@ import com.loopers.domain.product.ProductSearchCondition;
 import java.math.BigDecimal;
 
 public class ProductV1Dto {
-    public record ProductResponse(
+    public record ProductListResponse(
             Long productId,
             String name,
             Integer stock,
@@ -14,14 +14,36 @@ public class ProductV1Dto {
             String brandName,
             Long likeCount
     ) {
-        public static ProductResponse from(ProductResult info) {
-            return new ProductResponse(
+        public static ProductListResponse from(ProductResult info) {
+            return new ProductListResponse(
                     info.productId(),
                     info.name(),
                     info.stock(),
                     info.price(),
                     info.brandName(),
                     info.likeCount()
+            );
+        }
+    }
+
+    public record ProductDetailResponse(
+            Long productId,
+            String name,
+            Integer stock,
+            BigDecimal price,
+            String brandName,
+            Long likeCount,
+            Long rank
+    ) {
+        public static ProductDetailResponse from(ProductResult info) {
+            return new ProductDetailResponse(
+                    info.productId(),
+                    info.name(),
+                    info.stock(),
+                    info.price(),
+                    info.brandName(),
+                    info.likeCount(),
+                    info.rank()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Ranking V1 API", description = "상품 랭킹 관련 API 입니다.")
+public interface RankingV1ApiSpec {
+
+    @Operation(
+            summary = "일간 상품 랭킹 조회",
+            description = "날짜, 페이지 번호, 페이지당 상품 수에 따라 일간 상품 랭킹을 조회합니다."
+    )
+    @GetMapping("")
+    ApiResponse<List<RankingV1Dto.RankingResponse>> getRankings(
+            @Parameter(description = "조회 날짜 (yyyyMMdd)", example = "20250912")
+            @RequestParam(name = "date") String date,
+
+            @Parameter(description = "페이지 번호", example = "0")
+            @RequestParam(name = "page", defaultValue = "0") int page,
+
+            @Parameter(description = "페이지당 상품 수", example = "20")
+            @RequestParam(name = "size", defaultValue = "20") int size
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.product.ProductFacade;
+import com.loopers.application.product.ProductResult;
+import com.loopers.application.ranking.RankingService;
+import com.loopers.domain.product.ProductSearchCondition;
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/rankings")
+public class RankingV1Controller implements RankingV1ApiSpec {
+
+    private final RankingService rankingService;
+
+    @GetMapping
+    @Override
+    public ApiResponse<List<RankingV1Dto.RankingResponse>> getRankings(
+            @RequestParam("date") String date,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size
+    ) {
+        LocalDate parsedDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        List<ProductResult> products = rankingService.getTopProducts(parsedDate, page, size);
+        List<RankingV1Dto.RankingResponse> response = products.stream()
+                .map(RankingV1Dto.RankingResponse::from)
+                .toList();
+
+        return ApiResponse.success(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.product.ProductResult;
+import com.loopers.domain.product.ProductSearchCondition;
+
+import java.math.BigDecimal;
+
+public class RankingV1Dto {
+    public record RankingResponse(
+            Long productId,
+            String name,
+            Integer stock,
+            BigDecimal price,
+            String brandName,
+            Long likeCount,
+            Long rank
+    ) {
+        public static RankingResponse from(ProductResult info) {
+            return new RankingResponse(
+                    info.productId(),
+                    info.name(),
+                    info.stock(),
+                    info.price(),
+                    info.brandName(),
+                    info.likeCount(),
+                    info.rank()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/kafka/LikeChangedCacheEvictConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/kafka/LikeChangedCacheEvictConsumer.java
@@ -3,7 +3,7 @@ package com.loopers.collector.kafka;
 import com.loopers.collector.entity.EventHandled;
 import com.loopers.collector.repository.EventHandledRepository;
 import com.loopers.config.redis.RedisCacheConfig;
-import com.loopers.events.stock.StockAdjustedEvent;
+import com.loopers.events.like.LikeChangedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
@@ -15,38 +15,38 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class StockAdjustedCacheEvictConsumer {
+public class LikeChangedCacheEvictConsumer {
 
     private final EventHandledRepository eventHandledRepository;
     private final CacheManager cacheManager;
-
-    private static final String CONSUMER_NAME = "cache-evict";
+    private static final String CONSUMER_NAME = "like-cache-evict";
 
     @KafkaListener(
-            topics = "stock-events",
-            groupId = "stock-cache-consumer",
+            topics = "like-events",
+            groupId = "like-cache-consumer",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void handle(StockAdjustedEvent event, Acknowledgment ack) {
+    public void handle(LikeChangedEvent event, Acknowledgment ack) {
         try {
             String handledId = event.eventId() + ":" + CONSUMER_NAME;
             if (eventHandledRepository.findById(handledId).isPresent()) {
-                log.info("Duplicate StockAdjustedEvent. Skipping. eventId={}", event.eventId());
+                log.info("Duplicate LikeChangedEvent. Skipping. eventId={}", event.eventId());
                 ack.acknowledge();
                 return;
             }
 
-            if (event.newStock() == 0) {
-                Cache cache = cacheManager.getCache(RedisCacheConfig.CACHE_PRODUCT_DETAIL);
-                cache.evict(event.productId());
-                log.info("Cache evicted for productId={} (stock=0)", event.productId());
-            }
+            Cache detailCache = cacheManager.getCache(RedisCacheConfig.CACHE_PRODUCT_DETAIL);
+            Cache listCache = cacheManager.getCache(RedisCacheConfig.CACHE_PRODUCT_LIST);
+
+            detailCache.evict(event.productId());
+            listCache.clear();
+
+            log.info("Cache evicted for productId={} (like changed)", event.productId());
 
             eventHandledRepository.saveAndFlush(new EventHandled(event.eventId(), CONSUMER_NAME));
             ack.acknowledge();
-
         } catch (Exception e) {
-            log.error("Failed to process StockAdjustedEvent: {}", event, e);
+            log.error("Failed to process LikeChangedEvent: {}", event, e);
         }
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/kafka/LikeChangedEventConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/kafka/LikeChangedEventConsumer.java
@@ -25,8 +25,8 @@ public class LikeChangedEventConsumer {
     private static final String CONSUMER_NAME = "log";
 
     @KafkaListener(
-            topics = "catalog-events",
-            groupId = "catalog-consumer",
+            topics = "like-events",
+            groupId = "like-consumer",
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void handle(LikeChangedEvent event, Acknowledgment ack) {

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/kafka/LikeChangedMetricsConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/kafka/LikeChangedMetricsConsumer.java
@@ -24,8 +24,8 @@ public class LikeChangedMetricsConsumer {
     private static final String CONSUMER_NAME = "metrics";
 
     @KafkaListener(
-            topics = "catalog-events",
-            groupId = "catalog-metrics-consumer",
+            topics = "like-events",
+            groupId = "like-metrics-consumer",
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void handle(LikeChangedEvent event, Acknowledgment ack) {

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingConsumer.java
@@ -14,14 +14,14 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class RankingConsumer {
 
-    private final RankingRepository rankingRepository;
+    private final RankingWriter rankingWriter;
 
     @KafkaListener(topics = "like-events", groupId = "ranking-consumer")
     public void consumeLikeChanged(LikeChangedEvent event) {
         log.info("Consume LikeChangedEvent: {}", event);
 
         double score = RankingScore.fromLike();
-        rankingRepository.incrementScore(
+        rankingWriter.incrementScore(
                 LocalDate.now(),
                 event.productId().toString(),
                 score
@@ -34,7 +34,7 @@ public class RankingConsumer {
 
         event.items().forEach(item -> {
             double score = RankingScore.fromOrder(item.price(), item.quantity());
-            rankingRepository.incrementScore(
+            rankingWriter.incrementScore(
                     LocalDate.now(),
                     item.productId().toString(),
                     score

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingConsumer.java
@@ -1,0 +1,44 @@
+package com.loopers.collector.ranking;
+
+import com.loopers.events.like.LikeChangedEvent;
+import com.loopers.events.order.OrderPlacedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingConsumer {
+
+    private final RankingRepository rankingRepository;
+
+    @KafkaListener(topics = "like-events", groupId = "ranking-consumer")
+    public void consumeLikeChanged(LikeChangedEvent event) {
+        log.info("Consume LikeChangedEvent: {}", event);
+
+        double score = RankingScore.fromLike();
+        rankingRepository.incrementScore(
+                LocalDate.now(),
+                event.productId().toString(),
+                score
+        );
+    }
+
+    @KafkaListener(topics = "order-events", groupId = "ranking-consumer")
+    public void consumeOrderPlaced(OrderPlacedEvent event) {
+        log.info("Consume OrderPlacedEvent: {}", event);
+
+        event.items().forEach(item -> {
+            double score = RankingScore.fromOrder(item.price(), item.quantity());
+            rankingRepository.incrementScore(
+                    LocalDate.now(),
+                    item.productId().toString(),
+                    score
+            );
+        });
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingKeyGenerator.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingKeyGenerator.java
@@ -1,0 +1,18 @@
+package com.loopers.collector.ranking;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class RankingKeyGenerator {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final String PREFIX = "ranking:all:";
+
+    public static String dailyKey(LocalDate date) {
+        return PREFIX + date.format(FORMATTER);
+    }
+
+    public static long ttlSeconds() {
+        return 2 * 24 * 60 * 60;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingRepository.java
@@ -1,6 +1,6 @@
 package com.loopers.collector.ranking;
 
-
+import com.loopers.support.ranking.RankingKeyGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingRepository.java
@@ -1,0 +1,26 @@
+package com.loopers.collector.ranking;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void incrementScore(LocalDate date, String productId, double score) {
+        String key = RankingKeyGenerator.dailyKey(date);
+
+        redisTemplate.opsForZSet().incrementScore(key, productId, score);
+
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+            redisTemplate.expire(key, RankingKeyGenerator.ttlSeconds(), TimeUnit.SECONDS);
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingScore.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingScore.java
@@ -1,0 +1,17 @@
+package com.loopers.collector.ranking;
+
+import java.math.BigDecimal;
+
+public class RankingScore {
+
+    private static final double LIKE_WEIGHT = 0.3;
+    private static final double ORDER_WEIGHT = 0.7;
+
+    public static double fromLike() {
+        return LIKE_WEIGHT * 1;
+    }
+
+    public static double fromOrder(BigDecimal price, int amount) {
+        return ORDER_WEIGHT * price.multiply(BigDecimal.valueOf(amount)).doubleValue();
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingWriter.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/collector/ranking/RankingWriter.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
-public class RankingRepository {
+public class RankingWriter {
 
     private final StringRedisTemplate redisTemplate;
 

--- a/apps/commerce-collector/src/test/java/com/loopers/collector/kafka/LikeChangedEventConsumerTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/collector/kafka/LikeChangedEventConsumerTest.java
@@ -82,7 +82,7 @@ class LikeChangedEventConsumerTest {
                 .pollInterval(500, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
                     assertThat(eventHandledRepository.findById(handledId)).isPresent();
-                    assertThat(eventHandledRepository.count()).isEqualTo(2);
+                    assertThat(eventHandledRepository.count()).isEqualTo(3);
 
                     EventLog logEntry = eventLogRepository.findByEventId(eventId)
                             .orElseThrow();

--- a/apps/commerce-collector/src/test/java/com/loopers/collector/kafka/LikeChangedEventConsumerTest.java
+++ b/apps/commerce-collector/src/test/java/com/loopers/collector/kafka/LikeChangedEventConsumerTest.java
@@ -74,8 +74,8 @@ class LikeChangedEventConsumerTest {
         );
 
         // 동일 이벤트 두 번 발행
-        kafkaTemplate.send("catalog-events", String.valueOf(event.productId()), event).get(5, TimeUnit.SECONDS);
-        kafkaTemplate.send("catalog-events", String.valueOf(event.productId()), event).get(5, TimeUnit.SECONDS);
+        kafkaTemplate.send("like-events", String.valueOf(event.productId()), event).get(5, TimeUnit.SECONDS);
+        kafkaTemplate.send("like-events", String.valueOf(event.productId()), event).get(5, TimeUnit.SECONDS);
 
         await()
                 .atMost(5, TimeUnit.SECONDS)

--- a/modules/common-events/src/main/java/com/loopers/events/order/OrderPlacedEvent.java
+++ b/modules/common-events/src/main/java/com/loopers/events/order/OrderPlacedEvent.java
@@ -1,0 +1,17 @@
+package com.loopers.events.order;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record OrderPlacedEvent(
+        String orderId,
+        String userId,
+        BigDecimal totalAmount,
+        List<OrderItemDto> items
+) {
+    public record OrderItemDto(Long productId, int quantity, BigDecimal price) {}
+
+    public static OrderPlacedEvent of(String orderId, String userId, BigDecimal totalAmount, List<OrderItemDto> items) {
+        return new OrderPlacedEvent(orderId, userId, totalAmount, items);
+    }
+}

--- a/modules/common-support/src/main/java/com/loopers/support/ranking/RankingKeyGenerator.java
+++ b/modules/common-support/src/main/java/com/loopers/support/ranking/RankingKeyGenerator.java
@@ -1,4 +1,4 @@
-package com.loopers.collector.ranking;
+package com.loopers.support.ranking;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -13,11 +13,11 @@ spring:
       use.latest.version: true
     producer:
       acks: all
-      retries: 3
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         enable.idempotence: true
+        delivery.timeout.ms: 120000
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(
     ":modules:redis",
     ":modules:kafka",
     ":modules:common-events",
+    ":modules:common-support",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",
@@ -43,3 +44,5 @@ include("apps:commerce-collector")
 findProject(":apps:commerce-collector")?.name = "commerce-collector"
 include("modules:common-events")
 findProject(":modules:common-events")?.name = "common-events"
+include("modules:common-support")
+findProject(":modules:common-support")?.name = "common-support"


### PR DESCRIPTION
## 📌 Summary
- Redis ZSET
- Realtime Ranking
- Ranking API

## 💬 Review Points
- 상품 cache를 consumer가 삭제하도록 변경 [🔴 commit](https://github.com/kodonghee/loopers-e-commerce/pull/9/commits/6416d31c68cc7133ef72dd604e6f2232ae7e41aa)
  - 내부에서 상품 정보 캐시를 바로 삭제하도록 구현했었음
  - API 서비스 로직과 캐시 관리 로직의 분리
- 상품 조회 수에 대한 고민
  - 상품 상세 조회 API 호출 = 조회 타이밍으로 보면 되는 건지 고민
  - 새로 고침 같은 경우도 모두 조회수로 잡힐 수가 있음
- 배치로 랭킹 재집계 필요
  - 이벤트가 들어오자마자 Redis에 적재하면 실시간 랭킹 반영에 유리
  - 하지만 이벤트 유실 시 랭킹 데이터와 실제 데이터 간 불일치 가능성 있음
- common-support 모듈 생성 [🔴 commit](https://github.com/kodonghee/loopers-e-commerce/pull/9/commits/08314db00a8e4c45bf7be39b1c584fedc609eccd)
  - RankingKeyGenerator 같은 키 전략/TTL 유틸은 api/collector 양쪽에서 필요
  - 코드 중복이 줄고, 키 전략이 바뀌더라도 한 곳에서만 수정하면 됨
- ZINCRBY 사용 [🔴 commit](https://github.com/kodonghee/loopers-e-commerce/pull/9/commits/4a831e72f84e94afbf2d608c107c5adae9b3d67e)
  - 단순 SET/GET 대신 ZINCRBY를 사용해 원자적으로 점수를 누적시킴
  - 이벤트가 동시에 여러 건 들어와도 안전하게 집계 가능

## ✅ Checklist
### 📈 Ranking Consumer
- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API
- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

## 🔥 Feedback
<img width="830" height="566" alt="image" src="https://github.com/user-attachments/assets/11f0ebca-7186-4b52-80ac-f801a3be198d" />